### PR TITLE
Rocketry

### DIFF
--- a/src/ErrorDisplay.elm
+++ b/src/ErrorDisplay.elm
@@ -13,4 +13,7 @@ view me =
 
 
 errorStyle: Attribute
-errorStyle = Attr.style [("color", "red")]
+errorStyle = Attr.style [("color" => "red")]
+
+
+(=>) = (,)

--- a/src/EventTicker.elm
+++ b/src/EventTicker.elm
@@ -60,29 +60,32 @@ eventHighlight whom event =
            []
 
 
-highlightStyle = [("background-color", "gold")]
+highlightStyle = ["background-color" => "gold"]
 
 
 divStyle =
   style
     [
-      ("float", "left"),
-      ("width", "50%"),
-      ("box-sizing", "border-box"),
-      ("color", "#666666"),
-      ("overflow", "scroll"),
-      ("padding", "10px")
+      "float" => "left",
+      "width" => "50%",
+      "box-sizing" => "border-box",
+      "color" => "#666666",
+      "overflow" => "scroll",
+      "padding" => "10px"
     ]
+
+
+(=>) = (,)
 
 
 itemStyle: StylePortion -> Html.Attribute
 itemStyle highlight =
   style
     ([
-      ("color", "#515151"),
-      ("font-family", "Helvetica"),
-      ("font-size", "21px"),
-      ("height", "24px")
+      "color" => "#515151",
+      "font-family" => "Helvetica",
+      "font-size" => "21px",
+      "height" => "24px"
     ] ++ highlight)
 
 

--- a/src/Header.elm
+++ b/src/Header.elm
@@ -12,10 +12,10 @@ view model =
   Html.div
     [ Attr.style
       [
-        ("height", "100px"),
-        ("font-family", "Helvetica"),
-        ("margin-top", "20px"),
-        ("margin-left", "20px")
+        "height" => "100px",
+        "font-family" => "Helvetica",
+        "margin-top" => "20px",
+        "margin-left" => "20px"
       ]
     ]
   [
@@ -35,3 +35,5 @@ view model =
 
 repositoryLink repo = "http://github.com/" ++ repo.owner ++ "/" ++ repo.repo
 repositoryDescription repo = repo.owner ++ "'s " ++ repo.repo ++ " repository"
+
+(=>) = (,)

--- a/src/ReformattedFlickr.elm
+++ b/src/ReformattedFlickr.elm
@@ -32,23 +32,23 @@ view height string imgUrl =
 queryInputStyle : List (String, String)
 queryInputStyle =
     [
-        ("width",      "100%"),
-        ("height",     "40px"),
-        ("padding",    "10px 0"),
-        ("font-size",  "2em"),
-        ("text-align", "center")
+        "width" =>      "100%",
+        "height" =>     "40px",
+        "padding" =>    "10px 0",
+        "font-size" =>  "2em",
+        "text-align" => "center"
     ]
 
 
 imgStyle : Int -> String -> List (String, String)
 imgStyle height src =
     [
-        ("background-image",      "url('" ++ src ++ "')"),
-        ("background-repeat",     "no-repeat"),
-        ("background-attachment", "fixed"),
-        ("background-position",   "center"),
-        ("width",                 "100%"),
-        ("height",                (toString height) ++ "px")
+        "background-image" =>      "url('" ++ src ++ "')",
+        "background-repeat" =>     "no-repeat",
+        "background-attachment" => "fixed",
+        "background-position" =>   "center",
+        "width" =>                 "100%",
+        "height" =>                (toString height) ++ "px"
     ]
 
 
@@ -149,10 +149,10 @@ flickr : String -> List (String, String) -> String
 flickr method args =
     Http.url "https://api.flickr.com/services/rest/" <|
         [
-            ("format",         "json"),
-            ("nojsoncallback", "1"),
-            ("api_key",        "9be5b08cd8168fa82d136aa55f1fdb3c"),
-            ("method",         "flickr.photos." ++ method)
+            "format" =>         "json",
+            "nojsoncallback" => "1",
+            "api_key" =>        "9be5b08cd8168fa82d136aa55f1fdb3c",
+            "method" =>         "flickr.photos." ++ method
         ] ++ args
 
 

--- a/src/RepoInput.elm
+++ b/src/RepoInput.elm
@@ -19,5 +19,7 @@ view formclass =
 
 styles : Html.Attribute
 styles = Attr.style [
-          ("margin", "10px")
+          "margin" => "10px"
           ]
+
+(=>) = (,)

--- a/src/SeeThePeople.elm
+++ b/src/SeeThePeople.elm
@@ -77,8 +77,8 @@ view addr model =
 
 divStyle =
   Attr.style
-    [("float", "right"),
-     ("width", "50%")]
+    ["float" => "right",
+     "width" => "50%"]
 
 
 marginPx = 20
@@ -230,3 +230,6 @@ shrinkOver totalTime presentValue dt =
     if (nextPresent <= min)
     then PresentAndFuture min Constant
     else PresentAndFuture presentValue (Varying nextFunction)
+
+
+(=>) = (,)

--- a/src/SydronInt.elm
+++ b/src/SydronInt.elm
@@ -47,7 +47,7 @@ view addr m =
 
 
 inline: Html.Attribute
-inline = Attr.style [("display", "inline")]
+inline = Attr.style ["display" => "inline"]
 
 
 -- UPDATE
@@ -68,3 +68,6 @@ updatePeople action model =
 updateTicker : SydronAction -> Model -> Model
 updateTicker action model =
   { model | ticker <- EventTicker.update action model.ticker }
+
+
+(=>) = (,)


### PR DESCRIPTION
Instead of a custom helper function, you can get a nice DSL syntax out of just defining `=>` (this is a common alias for tuple creation.)

This also lets you remove some parens when defining styles.
